### PR TITLE
Fixed typos and unintroduced variables in classgroup.tex and commalg.tex

### DIFF
--- a/classgroup.tex
+++ b/classgroup.tex
@@ -24,7 +24,7 @@ books.
 \begin{definition}[Class Group]
 Let $\O_K$ be the ring of integers of a number field~$K$.  The
 \defn{class group} $C_K$ of~$K$ is the group of fractional ideals
-modulo the sugroup of principal fractional ideals $(a)$, for $a\in K$.
+modulo the subgroup of principal fractional ideals $(a)$, for $a\in K$.
 \end{definition}
 
 Note that if we let $\Div(\O_K)$ denote the group of  fractional
@@ -38,7 +38,7 @@ ideals of norm less than a given integer (Proposition~\ref{prop:finitewithnorm})
 \begin{theorem}[Finiteness of the Class Group]\label{thm:finiteclassgrp}
 \ithm{finiteness of class group}
 Let $K$ be a number field.  There is a constant $C_{r,s}$ that
-depends only on the number $r$, $s$ of real and pairs
+depends only on the numbers $r$, $s$ of real and pairs
 of complex conjugate embeddings of~$K$ such that
 every ideal class of $\O_K$ contains an integral ideal
 of norm at most $C_{r,s}\sqrt{|d_K|}$, where

--- a/commalg.tex
+++ b/commalg.tex
@@ -64,7 +64,7 @@ terms of groups.  Finally, we observe that
 the representation in the theorem is necessarily unique. 
 
 \begin{proposition}\label{prop:subfin}\iprop{subgroup of free group}
-If $H$ is a subgroup of a finitely generated abelian group, then $H$
+If $H$ is a subgroup of a finitely generated abelian group $G$, then $H$
 is finitely generated.
 \end{proposition}
 The key reason that this is true is that~$G$ is a finitely generated
@@ -1148,7 +1148,7 @@ $a^2-5b^2$ is an integer.  This proves that $\O_K = \Z[\varphi]$.
 \begin{example}
 The
 ring of integers of $K=\Q(\sqrt[3]{9})$ is $\Z[\sqrt[3]{3}]$, where
-$\sqrt[3]{3}=\frac{1}{3}(\sqrt[3]{9})^2 \not \in \sqrt[3]{9}$.  As we
+$\sqrt[3]{3}=\frac{1}{3}(\sqrt[3]{9})^2 \not \in \Z[\sqrt[3]{9}]$.  As we
 will see, in general the problem of computing $\O_K$ given $K$ may be
 very hard, since it requires factoring a certain potentially large
 integer.


### PR DESCRIPTION
3 minor typos.

In line 67 of commalg.tex, G is used in the next line but hasn't been introduced.
