### PR TITLE
Update commalg.tex

### DIFF
--- a/commalg.tex
+++ b/commalg.tex
@@ -599,7 +599,7 @@ contain many different maximal elements.
 	$R$-module structure induced from $\vphi$ (if $r\in R$
 	and $s\in S$, then we define $rs = \vphi(r)s$).
 	By Lemma~\ref{lem:noetherianexact}, it follows
-	that~$S$ is a noetherian $R$-modules. Suppose~$J$ is an ideal of~$S$.
+	that~$S$ is a noetherian $R$-module. Suppose~$J$ is an ideal of~$S$.
 	Since~$J$ is an $R$-submodule of~$S$, if we view~$J$ as an $R$-module,
 	then~$J$ is finitely generated. Since~$R$ acts on~$J$ through~$S$,
 	the $R$-generators of~$J$ are also $S$-generators of~$J$, so~$J$
@@ -806,7 +806,8 @@ there will be {\em many} isomorphisms between them.
 
 \begin{definition}[Algebraic Integer]
 	An element $\alpha\in\Qbar$ is an \defn{algebraic integer} if it
-	is a root of some monic polynomial with coefficients in~$\Z$.
+	is a root of some monic polynomial with coefficients in~$\Z$,
+	that is, $\alpha$ is integral over $\Z$.
 \end{definition}
 For example, $\sqrt{2}$ is an algebraic integer, since it is a root
 of the monic integral polynomial $x^2-2$. As we will see below,


### PR DESCRIPTION
Fixed another typo and included the definition of integral next to that of an algebraic integer since the term is used on the proof of the following proposition.